### PR TITLE
Updated schedule import behaviour to replace instance store if it wil…

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -46,7 +46,7 @@ Note that the output of all importer plugins shall be `PluginImporter.Output.Jso
 In addition to the meta-data, a minimal importer plugin only needs to define the static method `Result(rawSystem)`
 which returns a JSON object:
 ```javascript
-static Result(rawSystem) {
+static async Result(rawSystem) {
     // Convert rawSystem into a JSON string.
     const jsonString = ' ... ';
     
@@ -60,4 +60,9 @@ The JSON string is then converted into a JSON object using the method `JSON.pars
 LetSynchronise clears its database and stores the JSON object in the database. 
 
 An import plugin may also be used to import LET task schedules, but the plugin shall guarantee that the task, dependency, and event chain instances are consistent with their definitions in the LetSynchronise database (SystemInputStore, SystemOutputStore, TaskStore, DependencyStore, ConstraintStore, EventChainStore).
-Note that portions of a task schedule (e.g., only task instances) can be imported without modifying other scheduling information (e.g., dependencies instances).  
+Use the static method `DatabaseContents` in `` to retrieve a copy of the database contents as an object:
+```javascript
+const databaseContents = await PluginImporter.DatabaseContents;
+```  
+
+Note that portions of a task schedule (e.g., only task instances) can be imported without modifying other scheduling information (e.g., dependencies instances).

--- a/sources/ls.main.js
+++ b/sources/ls.main.js
@@ -88,7 +88,8 @@ controller.controllerAnalyse.controllerSchedule = controller.controllerSchedule;
 console.log(controller.toString());
 
 
-// Register plug-ins.
+// Register importer plug-ins.
+PluginImporter.ModelDatabase = model.modelDatabase;
 PluginImporter.Register(PluginImporterNative.Name, PluginImporterNative);
 PluginImporter.Register(PluginImporterTool1.Name, PluginImporterTool1);
 PluginImporter.Register(PluginImporterTudE2e.Name, PluginImporterTudE2e);
@@ -96,7 +97,7 @@ view.viewExportImport.updateSystemImporters();
 
 console.log(PluginImporter.ToString())
 
-
+// Register metric plug-ins.
 PluginMetric.Register(PluginMetricDataAge.Name, PluginMetricDataAge);
 PluginMetric.Register(PluginMetricEnd2End.Name, PluginMetricEnd2End);
 PluginMetric.Register(PluginMetricLatency.Name, PluginMetricLatency);

--- a/sources/model/ls.model.database.js
+++ b/sources/model/ls.model.database.js
@@ -180,12 +180,14 @@ class ModelDatabase {
         return schedule;
     }
     
-    deleteSchedule = function() {
+    deleteSchedule = function(instancesStoreNames) {
         let deletePromises = [ ];
-        
-        const instancesStoreNames = [
-            Model.TaskInstancesStoreName
-        ];
+
+        if (instancesStoreNames == null) {
+            instancesStoreNames = [... this.db.objectStoreNames];
+        }
+        instancesStoreNames = instancesStoreNames.filter(name => name.includes('Instance'));
+
         for (const instancesStoreName of instancesStoreNames) {
             deletePromises.push(this.deleteAllObjects(instancesStoreName));
         }

--- a/sources/model/ls.model.exportimport.js
+++ b/sources/model/ls.model.exportimport.js
@@ -75,9 +75,10 @@ class ModelExportImport {
             });
     }
     
-    // Importing a schedule overwrites the existing task, dependency, and event chain instances.
+    // Importing a schedule first clears the instance stores that the schedule will define.
     importSchedule(schedule) {
-        this.database.importSchedule(schedule)
+        this.database.deleteSchedule(Object.keys(schedule))
+            .then(this.database.importSchedule(schedule))
             .then(this.refreshViews());
     }
     

--- a/sources/model/ls.model.schedule.js
+++ b/sources/model/ls.model.schedule.js
@@ -266,6 +266,9 @@ class ModelSchedule {
     
     
     reinstantiateTasks(makespan) {
+        // Delete all task, dependency, and event chain instances.
+        this.database.deleteSchedule();
+        
         // Generate task instances.
         const promiseAllTasks = this.modelTask.getAllTasks();
         const promiseAllTasksInstances = promiseAllTasks

--- a/sources/plugins/ls.plugin.importer.js
+++ b/sources/plugins/ls.plugin.importer.js
@@ -20,7 +20,7 @@ class PluginImporter {
     }
 
 
-    // Plugin methods
+    // Plugin methods.
     static StoredPlugins = { };
     
     static GetPlugin(name) {
@@ -46,6 +46,23 @@ class PluginImporter {
     static Register(name, plugin) {
         PluginImporter.StoredPlugins[name] = plugin;
     }
+    
+    
+    // Plugin helper methods.
+    static _ModelDatabase = null;
+    
+    static set ModelDatabase(ModelDatabase) {
+        PluginImporter._ModelDatabase = ModelDatabase;
+    }
+    
+    static get ModelDatabase() {
+        return PluginImporter._ModelDatabase;
+    }
+    
+    static get DatabaseContents() {
+        return PluginImporter.ModelDatabase.exportSystem();
+    }
+    
     
     static ToString() {
         return 'PluginImporter loaded ...\n  ' + Object.keys(PluginImporter.Plugins).join(',\n  ');

--- a/sources/plugins/ls.plugin.importer.native.js
+++ b/sources/plugins/ls.plugin.importer.native.js
@@ -16,7 +16,7 @@ class PluginImporterNative {
     //
     // @Input system defined in native JSON format.
     // @Output system defined in the native JSON format.
-    static Result(rawSystem) {
+    static async Result(rawSystem) {
         // Simply returns the system.
         
         return JSON.parse(rawSystem);

--- a/sources/plugins/ls.plugin.importer.tool1.js
+++ b/sources/plugins/ls.plugin.importer.tool1.js
@@ -16,10 +16,14 @@ class PluginImporterTool1 {
     //
     // @Input system defined in XML1 format.
     // @Output system defined in the native JSON format.
-    static Result(system) {
+    static async Result(rawSystem) {
+        // Get a copy of the database contents.
+        const databaseContents = await PluginImporter.DatabaseContents;
+
         let json = '';
         
         // TODO: Walk through system and generate the required json.
+        // TODO: If needed, compare rawSystem contents with existing databaseContents to ensure consistency!
         alert(this.Name);
         
         return json;

--- a/sources/plugins/ls.plugin.importer.tudE2e.js
+++ b/sources/plugins/ls.plugin.importer.tudE2e.js
@@ -16,10 +16,14 @@ class PluginImporterTudE2e {
     //
     // @Input system defined in TXT format.
     // @Output system defined in the native JSON format.
-    static Result(rawSystem) {
+    static async Result(rawSystem) {
+        const databaseContents = await PluginImporter.DatabaseContents;
+        console.log(databaseContents);
+        
         alert(PluginImporterTudE2e.Name);
 
         // TODO: Parse rawSystem into a JSON string
+        // TODO: If needed, compare rawSystem contents with existing databaseContents to ensure consistency!
         const system =
         '{                                  \
             "TaskStore": [                  \

--- a/sources/view/ls.view.exportimport.js
+++ b/sources/view/ls.view.exportimport.js
@@ -85,8 +85,7 @@ class ViewExportImport {
             fileReader.readAsText(this.importSystemSelector.files.item(0));
         
             fileReader.onload = (event) => {
-                const result = pluginImporter.Result(event.target.result);
-                handler(result);
+                pluginImporter.Result(event.target.result).then(result => handler(result));
             }
         });
     }


### PR DESCRIPTION
…l be overwritten. Schedule is deleted when task instances are reinstantiated. Allow a copy of the database to be retrieved within an import plugin